### PR TITLE
Set ownership on /var/www/html

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,9 @@ COPY ./api /var/www/html/api
 COPY ./public /var/www/html/public
 
 # Set permissions
-RUN chown -R www-data:www-data /var/www/html
+RUN mkdir -p /var/www/html/public/notes && \
+    chown -R www-data:www-data /var/www/html && \
+    chmod -R 775 /var/www/html/public/notes
 
 # Create a startup script
 WORKDIR /var/www/html


### PR DESCRIPTION
closes #10 

As pointed out in https://github.com/alangrainger/share-note-self-hosted-backend/issues/10, without this patch the `/var/www/html/public/notes` directory ends up being owned by root and therefore causes file uploads to fail with

```
Failed to open stream: Permission denied
```